### PR TITLE
Add current error in url_search_issues link

### DIFF
--- a/src/invidious/helpers/errors.cr
+++ b/src/invidious/helpers/errors.cr
@@ -43,6 +43,8 @@ def error_template_helper(env : HTTP::Server::Context, status_code : Int32, exce
   # URLs for the error message below
   url_faq = "https://github.com/iv-org/documentation/blob/master/docs/faq.md"
   url_search_issues = "https://github.com/iv-org/invidious/issues"
+  url_search_issues += "?q=is:issue+is:open+"
+  url_search_issues += URI.encode_www_form("[Bug] " + issue_title)
 
   url_switch = "https://redirect.invidious.io" + env.request.resource
 


### PR DESCRIPTION
- Searches for the current instance error instead of dropping to general issue page in an attempt to cut down on duplicate issues being submitted to the instance.

Obviously not __ID10T__ proof but might stop some of them.. 🤣 
